### PR TITLE
Increase the maximum size of the generated configuration file from 1,000,000 to 2,000,000 bytes

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -24,7 +24,7 @@ const (
 )
 
 // limits generated configuration file size.
-const limit = 1000000
+const limit = 2000000
 
 var (
 	// ErrMainMissing indicates the starlark script is missing


### PR DESCRIPTION
I have a configuration file that is currently almost at the limit of 1,000,000 bytes:
```
-rw-r--r--  1 phil phil  42103 Feb  7 15:23 .drone.starlark
-rw-r--r--  1 phil phil 995815 Feb  7 15:23 .drone.yml
```

When I make some changes to the `.drone.starlark` to add a pipeline(s) then I go over the limit. This prevents the build from starting:
https://drone.owncloud.com/owncloud/encryption/1105
`starlark: maximum file size exceeded`

I have the same problem when I do not use the locally-generated `.drone.yml` and use a `.drone.star` directly.

IMO the limit here is artificial and just to protect "the system" from exploding if a starlark program is in a loop generating pipelines to infinity. Double the limit.